### PR TITLE
Add both general and Ansible linters

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,26 @@
+name: CI
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Setup Python
+        uses: actions/setup-python@v2
+
+      - name: Install pre-commit
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install --upgrade pre-commit
+
+      - name: Run pre-commit
+        run: |
+          python -m pre_commit run --all-files --show-diff-on-failure

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,18 @@
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.0.1
+    hooks:
+      - id: check-yaml
+      - id: check-case-conflict
+      - id: check-merge-conflict
+      - id: mixed-line-ending
+      - id: end-of-file-fixer
+      - id: fix-byte-order-marker
+      - id: trailing-whitespace
+
+  - repo: https://github.com/ansible-community/ansible-lint.git
+    rev: v5.1.3
+    hooks:
+      - id: ansible-lint
+        args: [-x, meta-no-info]
+        files: \.(yaml|yml)$

--- a/roles/caddy/tasks/main.yml
+++ b/roles/caddy/tasks/main.yml
@@ -36,12 +36,14 @@
   ansible.builtin.template:
     src: caddyfile.j2
     dest: /etc/caddy/Caddyfile
+    mode: 0644
   become: true
 
 - name: create conf.d directory to store virtual hosts
   ansible.builtin.file:
     path: "{{ caddy_confd_path }}"
     state: directory
+    mode: 0644
   become: true
 
 - name: start caddy now and on every reboot

--- a/roles/caddy_confd/tasks/main.yml
+++ b/roles/caddy_confd/tasks/main.yml
@@ -4,6 +4,7 @@
   ansible.builtin.template:
     src: vaultwarden.caddy.j2
     dest: "{{ (caddy_confd_path, 'vaultwarden.caddy') | path_join }}"
+    mode: 0644
   notify: reload-caddy
   when: groups['vaultwardens']
   become: true

--- a/roles/podman/tasks/main.yml
+++ b/roles/podman/tasks/main.yml
@@ -41,19 +41,20 @@
     cgroupsv2: "{{ cgroups.stat.isreg is defined and cgroups.stat.isreg }}"
 
 - block:
-  - name: update grub configuration to enable cgroups v2
-    ansible.builtin.lineinfile:
-      path: /etc/default/grub
-      regexp: '^GRUB_CMDLINE_LINUX="(.*)"$'
-      line: 'GRUB_CMDLINE_LINUX="\1 systemd.unified_cgroup_hierarchy=1"'
-      backrefs: yes
-      state: present
-    become: true
+    - name: update grub configuration template to enable cgroups v2
+      ansible.builtin.lineinfile:
+        path: /etc/default/grub
+        regexp: '^GRUB_CMDLINE_LINUX="(.*)"$'
+        line: 'GRUB_CMDLINE_LINUX="\1 systemd.unified_cgroup_hierarchy=1"'
+        backrefs: true
+        state: present
+      become: true
 
-  - ansible.builtin.command: update-grub
-    become: true
+    - name: update grub configuration
+      ansible.builtin.command: update-grub
+      become: true
 
-  - name: reboot the machine to apply the grub config changes
-    ansible.builtin.reboot:
-    become: true
+    - name: reboot the machine to apply the grub config changes
+      ansible.builtin.reboot:
+      become: true
   when: not cgroupsv2 and podman_require_cgroupsv2

--- a/roles/vaultwarden/tasks/main.yml
+++ b/roles/vaultwarden/tasks/main.yml
@@ -12,6 +12,7 @@
     path: "{{ item }}"
     owner: "{{ vaultwarden_user }}"
     group: "{{ vaultwarden_user }}"
+    mode: 0600
     state: directory
   with_items:
     - "{{ vaultwarden_data }}"
@@ -24,6 +25,7 @@
     dest: "{{ vaultwarden_etc }}/00-settings.sh"
     owner: "{{ vaultwarden_user }}"
     group: "{{ vaultwarden_user }}"
+    mode: 0600
     validate: bash %s
   become: true
 
@@ -31,6 +33,7 @@
   ansible.builtin.template:
     src: container-systemd.service.j2
     dest: /usr/lib/systemd/system/{{ vaultwarden_service_name }}.service
+    mode: 0644
   vars:
     user: "{{ vaultwarden_user }}"
     args:


### PR DESCRIPTION
In order to make sure no mistakes are made accidentally, including but
not limited to security issues, it's better to run various linters. This
patch adds a bunch of pre-commit builtin linters as well as ansible
linter, and fixes existing warnings and errors along the way.