### PR TITLE
Fix permissions for `/etc/caddy/conf.d`

### DIFF
--- a/roles/caddy/tasks/main.yml
+++ b/roles/caddy/tasks/main.yml
@@ -43,7 +43,7 @@
   ansible.builtin.file:
     path: "{{ caddy_confd_path }}"
     state: directory
-    mode: 0644
+    mode: 0755
   become: true
 
 - name: start caddy now and on every reboot


### PR DESCRIPTION
Commit e02a1b16ff1f776b4b200b4bf70558c8a99c333b has introduced explicit
permission modes on tasks that create files. Due to a silly mistake,
directory created for `/etc/caddy/conf.d` now has `0644` mode which
means directory could not be opened. This patch fixes this back adding
eXecutable flag to the mode.