### PR TITLE
Invoke Ansible handlers via topics, not names

### DIFF
--- a/roles/caddy/handlers/main.yml
+++ b/roles/caddy/handlers/main.yml
@@ -1,7 +1,8 @@
 ---
 
-- name: Reload caddy
+- name: Restart Caddy
   ansible.builtin.systemd:
     name: caddy.service
     state: restarted
+  listen: caddy-restart
   become: true

--- a/roles/caddy_confd/tasks/main.yml
+++ b/roles/caddy_confd/tasks/main.yml
@@ -1,9 +1,9 @@
 ---
 
-- name: Render vaultwarden caddy configuration
+- name: Render Caddy configuration for Vaultwarden
   ansible.builtin.template:
     src: vaultwarden.caddy.j2
     dest: "{{ (caddy_confd_path, 'vaultwarden.caddy') | path_join }}"
     mode: u=rw,g=r,o=r
-  notify: Reload caddy
+  notify: caddy-restart
   become: true

--- a/roles/wireguard/handlers/main.yml
+++ b/roles/wireguard/handlers/main.yml
@@ -1,7 +1,8 @@
 ---
 
-- name: Wireguard-systemd-networkd-restart
+- name: Restart systemd-networkd
   ansible.builtin.systemd:
     name: systemd-networkd.service
     state: restarted
+  listen: wireguard-systemd-networkd-restart
   become: true

--- a/roles/wireguard/tasks/main.yml
+++ b/roles/wireguard/tasks/main.yml
@@ -12,27 +12,27 @@
     state: present
   become: true
 
-- name: Create private key
+- name: Create a Wireguard private key
   ansible.builtin.copy:
     content: "{{ wireguard_private_key }}"
     dest: "{{ wireguard_private_key_path }}"
     group: systemd-network
     mode: u=rw,g=r,o=
-  notify: Wireguard-systemd-networkd-restart
+  notify: wireguard-systemd-networkd-restart
   become: true
 
-- name: Configure wireguard network device
+- name: Configure Wireguard network device
   ansible.builtin.template:
     src: systemd.netdev.j2
     dest: "{{ wireguard_systemd_networkd_path }}/{{ wireguard_device_name }}.netdev"
     mode: u=rw,g=r,o=r
-  notify: Wireguard-systemd-networkd-restart
+  notify: wireguard-systemd-networkd-restart
   become: true
 
-- name: Configure wireguard network
+- name: Configure Wireguard network
   ansible.builtin.template:
     src: systemd.network.j2
     dest: "{{ wireguard_systemd_networkd_path }}/{{ wireguard_device_name }}.network"
     mode: u=rw,g=r,o=r
-  notify: Wireguard-systemd-networkd-restart
+  notify: wireguard-systemd-networkd-restart
   become: true


### PR DESCRIPTION
Invoking Ansible handlers by names is weird and here's why:

 a. Names are human readable and may be long.
 b. Names may change in order to fix the spelling.
 c. Handlers are globally scopes and using unique names contradicts with
    names being human readable.

Fortunately there's another mechanism: pub/sub based on topics. This patch switches to topics for handlers invokation as these topics may be role-prefixed to ensure it's uniqueness and source of origin.