### PR TITLE
vaultwarden: remove websocket port

### DIFF
--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -26,7 +26,6 @@ vaultwarden_env_settings:
   INVITATION_ORG_NAME: The Vault
   SIGNUPS_ALLOWED: false
   SIGNUPS_VERIFY: true
-  WEBSOCKET_ENABLED: true
   SMTP_USERNAME: vault@m.kalnytskyi.com
   SMTP_PASSWORD: "{{ vaultwarden_smtp_password }}"
   SMTP_HOST: smtp.eu.mailgun.org

--- a/roles/caddy_confd/templates/vaultwarden.caddy.j2
+++ b/roles/caddy_confd/templates/vaultwarden.caddy.j2
@@ -7,8 +7,6 @@
     X-Robots-Tag "none"
   }
 
-  reverse_proxy /notifications/hub/negotiate {{ vaultwarden_host }}:{{vaultwarden_port }}
-  reverse_proxy /notifications/hub {{ vaultwarden_host }}:{{ vaultwarden_ws_port }}
   reverse_proxy {{ vaultwarden_host }}:{{ vaultwarden_port }} {
      # Passing correct remote IP address down to Vaultwarden so the latter
      # can correctly ban by IP.

--- a/roles/vaultwarden/defaults/main.yml
+++ b/roles/vaultwarden/defaults/main.yml
@@ -2,5 +2,4 @@
 
 vaultwarden_host: 127.0.0.1
 vaultwarden_port: 5000
-vaultwarden_ws_port: 5001
 vaultwarden_env_settings: {}

--- a/roles/vaultwarden/meta/main.yml
+++ b/roles/vaultwarden/meta/main.yml
@@ -18,11 +18,6 @@ argument_specs:
         default: 5000
         description: |
           The port to bind Vaultwarden to.
-      vaultwarden_ws_port:
-        type: int
-        default: 5001
-        description: |
-          The websocket port to bind Vaultwarden to.
       vaultwarden_env_settings:
         type: dict
         default: {}

--- a/roles/vaultwarden/templates/env.j2
+++ b/roles/vaultwarden/templates/env.j2
@@ -1,7 +1,5 @@
 ROCKET_ADDRESS="{{ vaultwarden_host }}"
 ROCKET_PORT="{{ vaultwarden_port }}"
-WEBSOCKET_ADDRESS="{{ vaultwarden_host }}"
-WEBSOCKET_PORT="{{ vaultwarden_ws_port }}"
 
 {% for k, v in vaultwarden_env_settings.items() %}
 {{ k }}="{{ v }}"


### PR DESCRIPTION
Starting with Vaultwarden 1.29 explicit websocket configuration is not required. Regular HTTP connection can be upgraded to Websocket when needed now.