### PR TITLE
Use 'latest-alpine' tag instead of 'alpine'

### DIFF
--- a/roles/vaultwarden/vars/main.yml
+++ b/roles/vaultwarden/vars/main.yml
@@ -1,5 +1,5 @@
 ---
 
-vaultwarden_image: docker://docker.io/vaultwarden/server:alpine
+vaultwarden_image: docker://docker.io/vaultwarden/server:latest-alpine
 vaultwarden_root: /opt/vaultwarden
 vaultwarden_etc: /etc/vaultwarden


### PR DESCRIPTION
The 'alpine' tag doesn't point to the latest version anymore. I don't know whether it's intentional change or not, but apparently there's now the 'latest-alpine' tag.