### PR TITLE
Make sure Vaultwarden is started on reboot

### DIFF
--- a/roles/vaultwarden/templates/systemd.service.j2
+++ b/roles/vaultwarden/templates/systemd.service.j2
@@ -31,3 +31,6 @@ ProtectProc=invisible
 RestrictNamespaces=true
 RestrictRealtime=true
 Restart=on-abnormal
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
Due to the missing `[Install]` section in `vaultwarden.service`, Vaultwarden hasn't been started on boot (or after reboot), which was annoying and unexpected. This patch fixes improper behaviour and makes sure the service is started on boot.