### PR TITLE
Use /etc/systemd for systemd units

### DIFF
--- a/roles/storage/tasks/systemd_mount.yml
+++ b/roles/storage/tasks/systemd_mount.yml
@@ -12,7 +12,7 @@
 - name: Render systemd mount unit
   ansible.builtin.template:
     src: systemd.mount.j2
-    dest: /usr/lib/systemd/system/{{ unit_name }}
+    dest: /etc/systemd/system/{{ unit_name }}
     mode: u=rw,g=r,o=r
   become: true
 

--- a/roles/vaultwarden/tasks/main.yml
+++ b/roles/vaultwarden/tasks/main.yml
@@ -25,7 +25,7 @@
 - name: Generate vaultwarden systemd service unit
   ansible.builtin.template:
     src: systemd.service.j2
-    dest: /usr/lib/systemd/system/vaultwarden.service
+    dest: /etc/systemd/system/vaultwarden.service
     mode: u=rw,g=r,o=r
   become: true
 


### PR DESCRIPTION
According to best practices, it's recommended to store units created by the administrator in /etc/systemd/ rather than in /usr/lib/systemd/. The /usr hierarchy is reserved to the units shipped by various software.