### PR TITLE
Ensure permissions of the mount point

### DIFF
--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -13,12 +13,13 @@ storage_mountpoints:
     options: defaults
     directory_mode: "0700"
 
-  # Vaultwarden is running with sandboxing configured with no access to
-  # block storage device. In order to spare ...
+  # Vaultwarden is running with sandboxing configured with no access to block
+  # storage device and without any knowledge about it. Let's just make sure
+  # that the directory Vaultwarden stores its state is mounted from the block
+  # storage.
   - what: /mnt/data/vaultwarden
     where: /var/lib/private/vaultwarden
     options: bind
-    directory_mode: "0700"
 
 vaultwarden_domain: vault.kalnytskyi.com
 vaultwarden_env_settings:

--- a/roles/storage/tasks/systemd_mount.yml
+++ b/roles/storage/tasks/systemd_mount.yml
@@ -23,3 +23,11 @@
     state: started
     daemon_reload: true
   become: true
+
+- name: Ensures permissions of the mount point
+  ansible.builtin.file:
+    path: "{{ item.where }}"
+    state: directory
+    mode: "{{ item.directory_mode }}"
+  when: item.directory_mode is defined
+  become: true


### PR DESCRIPTION
Turns out that setting DirectoryMode=0700 in the systemd mount unit is not enough, because that access mode is only used to create a mount point directory. Once mounted, the mount point acquires access mode of the mounted resource. This patch makes sure that the permissions are enforced when the unit is mounted and are back propagated to the mounted resource (be it a disk or another directory).

This is an important fix since it implies security aspect: the /mnt/data directory must have 0700 to act as a shield for its data, to make sure no one else has access to its content.