### PR TITLE
Add Kopia to backup /mnt/data content

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -44,6 +44,7 @@ jobs:
             -vv \
             --inventory inventory \
             --private-key '${{ steps.ssh-key.outputs.uri }}' \
+            --extra-vars kopia_repository_reconnect_token='${{ secrets.KOPIA_REPOSITORY_RECONNECT_TOKEN }}' \
             --extra-vars vaultwarden_smtp_password='${{ secrets.VAULTWARDEN_SMTP_PASSWORD }}' \
             --extra-vars vaultwarden_yubico_client_id='${{ secrets.VAULTWARDEN_YUBICO_CLIENT_ID }}' \
             --extra-vars vaultwarden_yubico_secret_key='${{ secrets.VAULTWARDEN_YUBICO_SECRET_KEY }}' \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,17 @@ jobs:
           python -m pre_commit run --all-files --show-diff-on-failure
 
   site:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
+
+    services:
+      webdav:
+        image: bytemark/webdav
+        env:
+          USERNAME: test
+          PASSWORD: test
+        ports:
+          - 8000:80
+
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
@@ -48,6 +58,21 @@ jobs:
           echo "uri=$VOLUME_DEVICE" >> $GITHUB_OUTPUT
         id: volume-device
 
+      - name: Create kopia repository
+        run: |
+          docker run --rm --interactive --network=host --entrypoint=/usr/bin/bash kopia/kopia - <<EOF \
+            | grep "kopia repository connect from-config" \
+            | awk '{print "reconnect-token="$NF}' \
+            >> $GITHUB_OUTPUT
+          export KOPIA_PASSWORD="1234"
+          export KOPIA_WEBDAV_USERNAME="test"
+          export KOPIA_WEBDAV_PASSWORD="test"
+
+          kopia repository create webdav --url=http://127.0.0.1:8000
+          kopia repository status --reconnect-token --reconnect-token-with-password
+          EOF
+        id: kopia-repository
+
       - name: Add server names to /etc/hosts
         run: |
           echo "127.0.0.1 hoth.kalnytskyi.local" | sudo tee -a /etc/hosts
@@ -61,6 +86,7 @@ jobs:
             --inventory "hoth," \
             --connection local \
             --extra-vars storage_device='${{ steps.volume-device.outputs.uri }}' \
+            --extra-vars kopia_repository_reconnect_token='${{ steps.kopia-repository.outputs.reconnect-token }}' \
             --extra-vars vaultwarden_domain='vault.kalnytskyi.local' \
             --extra-vars vaultwarden_smtp_password='sw0rdf1sh' \
             --extra-vars vaultwarden_yubico_client_id='' \

--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -1,6 +1,11 @@
 ---
 
+_storage_device_mountpoint: /mnt/data
+
 caddy_email: ihor@kalnytskyi.com
+
+kopia_snapshots:
+  - target: "{{ _storage_device_mountpoint }}"
 
 storage_device: /dev/disk/by-id/scsi-0HC_Volume_101710174
 storage_mountpoints:
@@ -8,7 +13,7 @@ storage_mountpoints:
   # root disks are ephemeral in many cloud providers, using block storage
   # device to persist your data is a good idea.
   - what: "{{ storage_device }}"
-    where: /mnt/data
+    where: "{{ _storage_device_mountpoint }}"
     type: ext4
     options: defaults
     directory_mode: "0700"

--- a/roles/kopia/meta/main.yml
+++ b/roles/kopia/meta/main.yml
@@ -1,0 +1,29 @@
+---
+
+argument_specs:
+  main:
+    options:
+      kopia_repository_reconnect_token:
+        type: str
+        required: true
+        description: |
+          Takes a reconnect token that encodes all repository connection
+          parameters and the repository (encryption) password. Despite not
+          being granular enough, this is the most ubiquitous way to support
+          various repository providers.
+
+          The reconnect token can be printed by executing the following
+          command:
+
+              kopia repository status --reconnect-token --reconnect-token-with-password
+      kopia_snapshots:
+        type: list
+        elements: dict
+        options:
+          target:
+            type: str
+            required: true
+            description: |
+              Takes an absolute path for periodic snapshots. The path can point
+              to either a directory or a file.
+        default: []

--- a/roles/kopia/tasks/main.yml
+++ b/roles/kopia/tasks/main.yml
@@ -1,0 +1,64 @@
+---
+
+- name: Add kopia apt repo signing key
+  ansible.builtin.apt_key:
+    url: "{{ kopia_apt_repo_gpg }}"
+    state: present
+  become: true
+
+- name: Add kopia apt repo
+  ansible.builtin.apt_repository:
+    repo: "{{ kopia_apt_repo_src }}"
+    state: present
+    filename: kopia
+  become: true
+
+- name: Install kopia
+  ansible.builtin.apt:
+    name: kopia
+    state: present
+  become: true
+
+- name: Create reconnect token systemd credential
+  ansible.builtin.command:
+    cmd: systemd-creds encrypt - /etc/credstore.encrypted/kopia-reconnect-token
+    stdin: "{{ kopia_repository_reconnect_token }}"
+  changed_when: true
+  become: true
+
+- name: Generate kopia repository connect service
+  ansible.builtin.template:
+    src: repository-connect.service.j2
+    dest: /etc/systemd/system/kopia-repository-connect.service
+    mode: u=rw,g=r,o=r
+  become: true
+
+- name: Generate kopia snapshot systemd service unit
+  ansible.builtin.template:
+    src: snapshot-create.service.j2
+    dest: /etc/systemd/system/kopia-snapshot-create.service
+    mode: u=rw,g=r,o=r
+  become: true
+
+- name: Generate kopia snapshots systemd timer unit
+  ansible.builtin.template:
+    src: snapshot-create.timer.j2
+    dest: /etc/systemd/system/kopia-snapshot-create.timer
+    mode: u=rw,g=r,o=r
+  become: true
+
+- name: Restart kopia repository connect
+  ansible.builtin.systemd:
+    name: kopia-repository-connect.service
+    enabled: true
+    state: restarted
+    daemon_reload: true
+  become: true
+
+- name: Start kopia snapshots timer now and on every reboot
+  ansible.builtin.systemd:
+    name: kopia-snapshot-create.timer
+    enabled: true
+    state: started
+    daemon_reload: true
+  become: true

--- a/roles/kopia/templates/repository-connect.service.j2
+++ b/roles/kopia/templates/repository-connect.service.j2
@@ -1,0 +1,43 @@
+[Unit]
+Description=Connect to the Kopia repository
+Documentation=https://kopia.io/docs/
+After=network.target network-online.target
+Requires=network-online.target
+
+[Service]
+Type=oneshot
+ExecStart=/usr/bin/kopia repository connect from-config \
+    --token-file %d/kopia-reconnect-token \
+    --override-username systemd
+LoadCredentialEncrypted=kopia-reconnect-token
+RemainAfterExit=true
+TemporaryFileSystem=/:ro
+BindReadOnlyPaths=/usr/bin/kopia
+BindReadOnlyPaths=/etc/ssl
+BindReadOnlyPaths=/etc/resolv.conf
+CacheDirectory=kopia
+ConfigurationDirectory=kopia
+LogsDirectory=kopia
+Environment=KOPIA_CHECK_FOR_UPDATES=false
+Environment=KOPIA_LOG_DIR=%L/kopia
+Environment=KOPIA_PERSIST_CREDENTIALS_ON_CONNECT=true
+Environment=XDG_CACHE_HOME=%C
+Environment=XDG_CONFIG_HOME=%E
+LockPersonality=true
+MemoryDenyWriteExecute=true
+PrivateDevices=true
+PrivateIPC=true
+PrivateTmp=true
+PrivateUsers=true
+ProtectClock=true
+ProtectControlGroups=true
+ProtectHostname=true
+ProtectKernelLogs=true
+ProtectKernelModules=true
+ProtectKernelTunables=true
+RestrictNamespaces=true
+RestrictRealtime=true
+RestrictSUIDSGID=true
+
+[Install]
+WantedBy=multi-user.target

--- a/roles/kopia/templates/snapshot-create.service.j2
+++ b/roles/kopia/templates/snapshot-create.service.j2
@@ -1,0 +1,39 @@
+[Unit]
+Description=Create Kopia snapshots
+Documentation=https://kopia.io/docs/
+After=network.target network-online.target
+Requires=network-online.target kopia-repository-connect.service
+After=kopia-repository-connect.service
+
+[Service]
+Type=oneshot
+{% for snapshot in kopia_snapshots %}
+ExecStart=/usr/bin/kopia snapshot create {{ snapshot.target }}
+{% endfor %}
+TemporaryFileSystem=/:ro
+BindReadOnlyPaths=/usr/bin/kopia
+BindReadOnlyPaths=/etc/ssl
+BindReadOnlyPaths=/etc/resolv.conf
+{% for snapshot in kopia_snapshots %}
+BindReadOnlyPaths={{ snapshot.target }}
+{% endfor %}
+CacheDirectory=kopia
+ConfigurationDirectory=kopia
+LogsDirectory=kopia
+Environment=XDG_CACHE_HOME=%C
+Environment=XDG_CONFIG_HOME=%E
+LockPersonality=true
+MemoryDenyWriteExecute=true
+PrivateDevices=true
+PrivateIPC=true
+PrivateTmp=true
+PrivateUsers=true
+ProtectClock=true
+ProtectControlGroups=true
+ProtectHostname=true
+ProtectKernelLogs=true
+ProtectKernelModules=true
+ProtectKernelTunables=true
+RestrictNamespaces=true
+RestrictRealtime=true
+RestrictSUIDSGID=true

--- a/roles/kopia/templates/snapshot-create.timer.j2
+++ b/roles/kopia/templates/snapshot-create.timer.j2
@@ -1,0 +1,10 @@
+[Unit]
+Description=Create Kopia snapshots every hour
+Documentation=https://kopia.io/docs/
+
+[Timer]
+OnCalendar=hourly
+Persistent=true
+
+[Install]
+WantedBy=timers.target

--- a/roles/kopia/vars/main.yml
+++ b/roles/kopia/vars/main.yml
@@ -1,0 +1,4 @@
+---
+
+kopia_apt_repo_src: deb https://packages.kopia.io/apt/ stable main
+kopia_apt_repo_gpg: https://kopia.io/signing-key

--- a/site.yml
+++ b/site.yml
@@ -4,6 +4,7 @@
   hosts: hoth
   roles:
     - role: storage
+    - role: kopia
     - role: wireguard
     - role: vaultwarden
     - role: caddy


### PR DESCRIPTION
Kopia is a fast and secure open-source backup/restore tool that allows you to create encrypted snapshots of your data and save the snapshots to remote or cloud storage of your choice. This patch delivers a basic Ansible role to install and configure Kopia for periodic backups via systemd timers.

The kopia binary is sandboxed and has only access to bare minimum.