### PR TITLE
Run kopia-snapshot-create.service as root

### DIFF
--- a/roles/kopia/templates/snapshot-create.service.j2
+++ b/roles/kopia/templates/snapshot-create.service.j2
@@ -27,7 +27,6 @@ MemoryDenyWriteExecute=true
 PrivateDevices=true
 PrivateIPC=true
 PrivateTmp=true
-PrivateUsers=true
 ProtectClock=true
 ProtectControlGroups=true
 ProtectHostname=true


### PR DESCRIPTION
The `PrivateUsers=true` option implies user namespacing, which means when accessing a file or a directory a `root` user inside namespace is mapped back to unprivileged user on the host before checking access bit mask. Since Kopia takes snapshots of files and directories owned by a different users, we need to run it from a real `root` user to make sure it has access to _all_ directories.