### PR TITLE
Turn Vaultwarden/Bitwarden push notifications on

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -45,6 +45,8 @@ jobs:
             --inventory inventory \
             --private-key '${{ steps.ssh-key.outputs.uri }}' \
             --extra-vars kopia_repository_reconnect_token='${{ secrets.KOPIA_REPOSITORY_RECONNECT_TOKEN }}' \
+            --extra-vars vaultwarden_push_installation_id='${{ secrets.VAULTWARDEN_PUSH_INSTALLATION_ID }}' \
+            --extra-vars vaultwarden_push_installation_key='${{ secrets.VAULTWARDEN_PUSH_INSTALLATION_KEY }}' \
             --extra-vars vaultwarden_smtp_password='${{ secrets.VAULTWARDEN_SMTP_PASSWORD }}' \
             --extra-vars vaultwarden_yubico_client_id='${{ secrets.VAULTWARDEN_YUBICO_CLIENT_ID }}' \
             --extra-vars vaultwarden_yubico_secret_key='${{ secrets.VAULTWARDEN_YUBICO_SECRET_KEY }}' \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,6 +88,8 @@ jobs:
             --extra-vars storage_device='${{ steps.volume-device.outputs.uri }}' \
             --extra-vars kopia_repository_reconnect_token='${{ steps.kopia-repository.outputs.reconnect-token }}' \
             --extra-vars vaultwarden_domain='vault.kalnytskyi.local' \
+            --extra-vars vaultwarden_push_installation_id='id' \
+            --extra-vars vaultwarden_push_installation_key='key' \
             --extra-vars vaultwarden_smtp_password='sw0rdf1sh' \
             --extra-vars vaultwarden_yubico_client_id='' \
             --extra-vars vaultwarden_yubico_secret_key='' \

--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -40,6 +40,11 @@ vaultwarden_env_settings:
   SMTP_PORT: 587
   YUBICO_CLIENT_ID: "{{ vaultwarden_yubico_client_id }}"
   YUBICO_SECRET_KEY: "{{ vaultwarden_yubico_secret_key }}"
+  PUSH_ENABLED: true
+  PUSH_INSTALLATION_ID: "{{ vaultwarden_push_installation_id }}"
+  PUSH_INSTALLATION_KEY: "{{ vaultwarden_push_installation_key }}"
+  PUSH_RELAY_URI: https://api.bitwarden.eu
+  PUSH_IDENTITY_URI: https://identity.bitwarden.eu
   ROCKET_CLI_COLORS: false
   ROCKET_WORKERS: 5
 


### PR DESCRIPTION
One can activate Mobile Client push notifications to automatically sync your personal vault between the mobile app, the web extension and the web vault without the need to sync manually. Let's do this! It sounds convenient.

https://github.com/dani-garcia/vaultwarden/wiki/Enabling-Mobile-Client-push-notification