### PR TITLE
Use deb822_repository to setup repos

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,5 +18,5 @@ repos:
     rev: v6.13.1
     hooks:
       - id: ansible-lint
-        args: [-x, meta-no-info]
+        args: [-x, "meta-no-info,no-handler"]
         files: \.(yaml|yml)$

--- a/roles/caddy/tasks/main.yml
+++ b/roles/caddy/tasks/main.yml
@@ -1,29 +1,21 @@
 ---
 
+- name: Add caddy deb repo
+  ansible.builtin.deb822_repository: "{{ caddy_deb_repo }}"
+  register: caddy_deb_repo_result
+  become: true
+
 - name: Update apt cache if needed
   ansible.builtin.apt:
     update_cache: true
     cache_valid_time: 3600
+  when: caddy_deb_repo_result.changed
   become: true
 
 - name: Install apt prerequisite packages
   ansible.builtin.apt:
-    name: "{{ caddy_apt_prerequisite_packages }}"
+    name: "{{ caddy_prerequisite_packages }}"
     state: present
-  become: true
-
-- name: Add caddy apt repo signing key
-  ansible.builtin.apt_key:
-    url: "{{ caddy_apt_repo_gpg }}"
-    state: present
-  become: true
-
-- name: Add caddy apt repo
-  ansible.builtin.apt_repository:
-    repo: "{{ item }}"
-    state: present
-    filename: caddy
-  with_items: "{{ caddy_apt_repo_src }}"
   become: true
 
 - name: Install caddy

--- a/roles/caddy/vars/main.yml
+++ b/roles/caddy/vars/main.yml
@@ -1,10 +1,13 @@
 ---
 
-caddy_apt_prerequisite_packages:
+caddy_prerequisite_packages:
   - debian-keyring
   - debian-archive-keyring
   - apt-transport-https
-caddy_apt_repo_src:
-  - deb https://dl.cloudsmith.io/public/caddy/stable/deb/debian any-version main
-  - deb-src https://dl.cloudsmith.io/public/caddy/stable/deb/debian any-version main
-caddy_apt_repo_gpg: https://dl.cloudsmith.io/public/caddy/stable/gpg.key
+caddy_deb_repo:
+  name: caddy
+  types: deb
+  uris: https://dl.cloudsmith.io/public/caddy/stable/deb/debian
+  suites: any-version
+  components: main
+  signed_by: https://dl.cloudsmith.io/public/caddy/stable/gpg.key

--- a/roles/kopia/tasks/main.yml
+++ b/roles/kopia/tasks/main.yml
@@ -1,16 +1,15 @@
 ---
 
-- name: Add kopia apt repo signing key
-  ansible.builtin.apt_key:
-    url: "{{ kopia_apt_repo_gpg }}"
-    state: present
+- name: Add kopia deb repo
+  ansible.builtin.deb822_repository: "{{ kopia_deb_repo }}"
+  register: kopia_deb_repo_result
   become: true
 
-- name: Add kopia apt repo
-  ansible.builtin.apt_repository:
-    repo: "{{ kopia_apt_repo_src }}"
-    state: present
-    filename: kopia
+- name: Update apt cache if needed
+  ansible.builtin.apt:
+    update_cache: true
+    cache_valid_time: 3600
+  when: kopia_deb_repo_result.changed
   become: true
 
 - name: Install kopia

--- a/roles/kopia/vars/main.yml
+++ b/roles/kopia/vars/main.yml
@@ -1,4 +1,9 @@
 ---
 
-kopia_apt_repo_src: deb https://packages.kopia.io/apt/ stable main
-kopia_apt_repo_gpg: https://kopia.io/signing-key
+kopia_deb_repo:
+  name: kopia
+  types: deb
+  uris: https://packages.kopia.io/apt/
+  suites: stable
+  components: main
+  signed_by: https://kopia.io/signing-key


### PR DESCRIPTION
Apparently the apt_key binary is deprecated and is no longer recommended to be used. If one wants to verify signatures now, it's recommended to use new deb 822 format. This patch replaces apt_repository and apt_key invocations with single deb822_repository.