### PR TITLE
Use systemd-creds to pass secrets to Vaultwarden

### DIFF
--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -27,22 +27,28 @@ storage_mountpoints:
     options: bind
 
 vaultwarden_domain: vault.kalnytskyi.com
+vaultwarden_secrets:
+  vaultwarden-smtp-password: "{{ vaultwarden_smtp_password }}"
+  vaultwarden-yubico-client-id: "{{ vaultwarden_yubico_client_id }}"
+  vaultwarden-yubico-secret-key: "{{ vaultwarden_yubico_secret_key }}"
+  vaultwarden-push-installation-id: "{{ vaultwarden_push_installation_id }}"
+  vaultwarden-push-installation-key: "{{ vaultwarden_push_installation_key }}"
 vaultwarden_env_settings:
   DOMAIN: https://{{ vaultwarden_domain }}
   INVITATION_ORG_NAME: The Vault
   SIGNUPS_ALLOWED: false
   SIGNUPS_VERIFY: true
   SMTP_USERNAME: vault@m.kalnytskyi.com
-  SMTP_PASSWORD: "{{ vaultwarden_smtp_password }}"
+  SMTP_PASSWORD_FILE: "%d/vaultwarden-smtp-password"
   SMTP_HOST: smtp.eu.mailgun.org
   SMTP_FROM: vault@kalnytskyi.com
   SMTP_FROM_NAME: The Vault
   SMTP_PORT: 587
-  YUBICO_CLIENT_ID: "{{ vaultwarden_yubico_client_id }}"
-  YUBICO_SECRET_KEY: "{{ vaultwarden_yubico_secret_key }}"
-  PUSH_ENABLED: true
-  PUSH_INSTALLATION_ID: "{{ vaultwarden_push_installation_id }}"
-  PUSH_INSTALLATION_KEY: "{{ vaultwarden_push_installation_key }}"
+  YUBICO_CLIENT_ID_FILE: "%d/vaultwarden-yubico-client-id"
+  YUBICO_SECRET_KEY_FILE: "%d/vaultwarden-yubico-secret-key"
+  PUSH_ENABLED: "{{ (vaultwarden_push_installation_id and vaultwarden_push_installation_key) | bool }}"
+  PUSH_INSTALLATION_ID_FILE: "%d/vaultwarden-push-installation-id"
+  PUSH_INSTALLATION_KEY_FILE: "%d/vaultwarden-push-installation-key"
   PUSH_RELAY_URI: https://api.bitwarden.eu
   PUSH_IDENTITY_URI: https://identity.bitwarden.eu
   ROCKET_CLI_COLORS: false

--- a/roles/vaultwarden/tasks/main.yml
+++ b/roles/vaultwarden/tasks/main.yml
@@ -1,5 +1,13 @@
 ---
 
+- name: Create Vaultwarden secret
+  ansible.builtin.command:
+    cmd: systemd-creds encrypt - /etc/credstore.encrypted/{{ item.key }}
+    stdin: "{{ item.value }}"
+  loop: "{{ vaultwarden_secrets | dict2items }}"
+  changed_when: true
+  become: true
+
 - name: Fetch and unpack Vaultwarden image
   oci_image_unpack:
     image: "{{ vaultwarden_image }}"
@@ -13,13 +21,6 @@
     state: directory
   with_items:
     - "{{ vaultwarden_etc }}"
-  become: true
-
-- name: Configure vaultwarden
-  ansible.builtin.template:
-    src: env.j2
-    dest: "{{ vaultwarden_etc }}/env"
-    mode: u=rw,g=,o=
   become: true
 
 - name: Generate vaultwarden systemd service unit

--- a/roles/vaultwarden/templates/env.j2
+++ b/roles/vaultwarden/templates/env.j2
@@ -1,6 +1,0 @@
-ROCKET_ADDRESS="{{ vaultwarden_host }}"
-ROCKET_PORT="{{ vaultwarden_port }}"
-
-{% for k, v in vaultwarden_env_settings.items() %}
-{{ k }}="{{ v }}"
-{% endfor %}

--- a/roles/vaultwarden/templates/systemd.service.j2
+++ b/roles/vaultwarden/templates/systemd.service.j2
@@ -13,7 +13,14 @@ CacheDirectory=vaultwarden
 Environment=DATA_FOLDER=%S/vaultwarden
 Environment=ICON_CACHE_FOLDER=%C/vaultwarden/icons
 Environment=TMP_FOLDER=%T
-EnvironmentFile=%E/vaultwarden/env
+Environment=ROCKET_ADDRESS={{ vaultwarden_host }}
+Environment=ROCKET_PORT={{ vaultwarden_port }}
+{% for name, value in vaultwarden_env_settings.items() %}
+Environment="{{ name }}={{ value }}"
+{% endfor %}
+{% for name in vaultwarden_secrets %}
+LoadCredentialEncrypted={{ name }}
+{% endfor %}
 DevicePolicy=closed
 DynamicUser=true
 LockPersonality=true


### PR DESCRIPTION
The systemd service manager supports a “credential” concept for securely acquiring and passing credential data to systems and services. Passing secrets through environment variables is considered insecure because they are inherited down the process tree.

This patch switches the Vaultwarden service to consume secrets from files provided for this service only through systemd credentials.