### PR TITLE
Turn off SSH password authentication

### DIFF
--- a/roles/hardening/handlers/main.yml
+++ b/roles/hardening/handlers/main.yml
@@ -1,0 +1,8 @@
+---
+
+- name: Restart sshd
+  ansible.builtin.systemd:
+    name: ssh.service
+    state: restarted
+  listen: security-systemd-sshd-restart
+  become: true

--- a/roles/hardening/tasks/main.yml
+++ b/roles/hardening/tasks/main.yml
@@ -1,0 +1,9 @@
+---
+
+- name: Turn off SSH password authentication
+  ansible.builtin.copy:
+    content: PasswordAuthentication no
+    dest: /etc/ssh/sshd_config.d/10-no-password-authentication.conf
+    mode: u=rw,g=r,o=r
+  notify: security-systemd-sshd-restart
+  become: true

--- a/site.yml
+++ b/site.yml
@@ -3,6 +3,7 @@
 - name: Provision
   hosts: hoth
   roles:
+    - role: hardening
     - role: storage
     - role: kopia
     - role: wireguard


### PR DESCRIPTION
Password authentication is weak. I don't use it, and I don't need it. In order to better secure my VM, I better turn it off for good.