### PR TITLE
Avoid using bulk-set task arguments

### DIFF
--- a/roles/caddy/tasks/main.yml
+++ b/roles/caddy/tasks/main.yml
@@ -1,7 +1,13 @@
 ---
 
 - name: Add caddy deb repo
-  ansible.builtin.deb822_repository: "{{ caddy_deb_repo }}"
+  ansible.builtin.deb822_repository:
+    name: "{{ caddy_deb_repo_name }}"
+    types: "{{ caddy_deb_repo_types }}"
+    uris: "{{ caddy_deb_repo_uris }}"
+    suites: "{{ caddy_deb_repo_suites }}"
+    components: "{{ caddy_deb_repo_components }}"
+    signed_by: "{{ caddy_deb_repo_signed_by }}"
   register: caddy_deb_repo_result
   become: true
 
@@ -29,6 +35,7 @@
     src: caddyfile.j2
     dest: /etc/caddy/Caddyfile
     mode: u=rw,g=r,o=r
+  notify: caddy-restart
   become: true
 
 - name: Create conf.d directory to store virtual hosts
@@ -38,9 +45,8 @@
     mode: u=rwx,g=rx,o=rx
   become: true
 
-- name: Start caddy now and on every reboot
+- name: Start caddy on every reboot
   ansible.builtin.systemd:
     name: caddy.service
     enabled: true
-    state: restarted
   become: true

--- a/roles/caddy/vars/main.yml
+++ b/roles/caddy/vars/main.yml
@@ -4,10 +4,9 @@ caddy_prerequisite_packages:
   - debian-keyring
   - debian-archive-keyring
   - apt-transport-https
-caddy_deb_repo:
-  name: caddy
-  types: deb
-  uris: https://dl.cloudsmith.io/public/caddy/stable/deb/debian
-  suites: any-version
-  components: main
-  signed_by: https://dl.cloudsmith.io/public/caddy/stable/gpg.key
+caddy_deb_repo_name: caddy
+caddy_deb_repo_types: deb
+caddy_deb_repo_uris: https://dl.cloudsmith.io/public/caddy/stable/deb/debian
+caddy_deb_repo_suites: any-version
+caddy_deb_repo_components: main
+caddy_deb_repo_signed_by: https://dl.cloudsmith.io/public/caddy/stable/gpg.key

--- a/roles/kopia/tasks/main.yml
+++ b/roles/kopia/tasks/main.yml
@@ -1,7 +1,13 @@
 ---
 
 - name: Add kopia deb repo
-  ansible.builtin.deb822_repository: "{{ kopia_deb_repo }}"
+  ansible.builtin.deb822_repository:
+    name: "{{ kopia_deb_repo_name }}"
+    types: "{{ kopia_deb_repo_types }}"
+    uris: "{{ kopia_deb_repo_uris }}"
+    suites: "{{ kopia_deb_repo_suites }}"
+    components: "{{ kopia_deb_repo_components }}"
+    signed_by: "{{ kopia_deb_repo_signed_by }}"
   register: kopia_deb_repo_result
   become: true
 

--- a/roles/kopia/vars/main.yml
+++ b/roles/kopia/vars/main.yml
@@ -1,9 +1,8 @@
 ---
 
-kopia_deb_repo:
-  name: kopia
-  types: deb
-  uris: https://packages.kopia.io/apt/
-  suites: stable
-  components: main
-  signed_by: https://kopia.io/signing-key
+kopia_deb_repo_name: kopia
+kopia_deb_repo_types: deb
+kopia_deb_repo_uris: https://packages.kopia.io/apt/
+kopia_deb_repo_suites: stable
+kopia_deb_repo_components: main
+kopia_deb_repo_signed_by: https://kopia.io/signing-key


### PR DESCRIPTION
You can set all of a task’s arguments from a dictionary-typed variable. This technique can be useful in some dynamic execution scenarios. However, it introduces a security risk, and therefore Ansible issues a warning when you do something like this.