### PR TITLE
Add the jumphost SSH user

### DIFF
--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -4,6 +4,9 @@ _storage_device_mountpoint: /mnt/data
 
 caddy_email: ihor@kalnytskyi.com
 
+jumphost_authorized_keys:
+  - ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIEwn8Vak70MKJqJwKofCvWsd7RzeYlL+So3+26u68Izb gh-action@xsnippet-infra
+
 kopia_snapshots:
   - target: "{{ _storage_device_mountpoint }}"
 

--- a/roles/jumphost/tasks/main.yml
+++ b/roles/jumphost/tasks/main.yml
@@ -1,0 +1,17 @@
+---
+
+- name: Setup a dedicated user
+  ansible.builtin.user:
+    name: "{{ jumphost_user }}"
+    home: "{{ jumphost_home }}"
+    shell: "{{ jumphost_nologin }}"
+    state: present
+  become: true
+
+- name: Setup an authorized SSH key
+  ansible.posix.authorized_key:
+    user: "{{ jumphost_user }}"
+    key: "{{ item }}"
+    state: present
+  loop: "{{ jumphost_authorized_keys }}"
+  become: true

--- a/roles/jumphost/vars/main.yml
+++ b/roles/jumphost/vars/main.yml
@@ -1,0 +1,5 @@
+---
+
+jumphost_user: bunny
+jumphost_home: /var/lib/{{ jumphost_user }}
+jumphost_nologin: /sbin/nologin

--- a/site.yml
+++ b/site.yml
@@ -6,6 +6,7 @@
     - role: hardening
     - role: storage
     - role: kopia
+    - role: jumphost
     - role: wireguard
     - role: vaultwarden
     - role: caddy


### PR DESCRIPTION
This one is tricky. Since I don't have IPv6 on my home machine, I seldom need a host through which I can get IPv6 connectivity to various machines in the Internet. This patch sets the jumphost user.