### PR TITLE
Add Ntfy push notifications

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -51,4 +51,7 @@ jobs:
             --extra-vars vaultwarden_yubico_client_id='${{ secrets.VAULTWARDEN_YUBICO_CLIENT_ID }}' \
             --extra-vars vaultwarden_yubico_secret_key='${{ secrets.VAULTWARDEN_YUBICO_SECRET_KEY }}' \
             --extra-vars wireguard_private_key='${{ secrets.WIREGUARD_PRIVATE_KEY }}' \
+            --extra-vars ntfy_smtp_password='${{ secrets.NTFY_SMTP_PASSWORD }}' \
+            --extra-vars ntfy_webpush_key_pub='${{ vars.NTFY_WEBPUSH_KEY_PUB }}' \
+            --extra-vars ntfy_webpush_key='${{ secrets.NTFY_WEBPUSH_KEY }}' \
             site.yml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,6 +77,7 @@ jobs:
         run: |
           echo "127.0.0.1 hoth.kalnytskyi.local" | sudo tee -a /etc/hosts
           echo "127.0.0.1 vault.kalnytskyi.local" | sudo tee -a /etc/hosts
+          echo "127.0.0.1 ntfy.kalnytskyi.local" | sudo tee -a /etc/hosts
 
       - name: Run the playbook
         run: |
@@ -94,4 +95,8 @@ jobs:
             --extra-vars vaultwarden_yubico_client_id='' \
             --extra-vars vaultwarden_yubico_secret_key='' \
             --extra-vars wireguard_private_key='qOanPI1Z6XlEcR+ebyPB7z5qr6F2S0FZP7iWe+4AqVA=' \
+            --extra-vars ntfy_domain='ntfy.kalnytskyi.local' \
+            --extra-vars ntfy_smtp_password='sw0rdf1sh' \
+            --extra-vars ntfy_webpush_key_pub='pubkey' \
+            --extra-vars ntfy_webpush_key='key' \
             site.yml

--- a/README.md
+++ b/README.md
@@ -16,6 +16,13 @@ be available on the provisioner node:
 
 ## Services
 
+### [Ntfy]
+
+ntfy lets you send push notifications to your phone or desktop via scripts from
+any computer, using simple HTTP PUT or POST requests.
+
+[Ntfy]: https://docs.ntfy.sh
+
 ### [Vaultwarden]
 
 Alternative implementation of the Bitwarden server API written in Rust and

--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -11,6 +11,12 @@ jumphost_authorized_keys:
 kopia_snapshots:
   - target: "{{ _storage_device_mountpoint }}"
 
+ntfy_domain: ntfy.kalnytskyi.com
+ntfy_smtp_hostname: smtp.eu.mailgun.org
+ntfy_smtp_username: ntfy@m.kalnytskyi.com
+ntfy_smtp_from: ntfy@kalnytskyi.com
+ntfy_webpush_email: ihor@kalnytskyi.com
+
 storage_device: /dev/disk/by-id/scsi-0HC_Volume_101710174
 storage_mountpoints:
   # The block storage device to store the most important data on. Since VMs
@@ -22,12 +28,12 @@ storage_mountpoints:
     options: defaults
     directory_mode: "0700"
 
-  # Vaultwarden is running with sandboxing configured with no access to block
-  # storage device and without any knowledge about it. Let's just make sure
-  # that the directory Vaultwarden stores its state is mounted from the block
-  # storage.
   - what: /mnt/data/vaultwarden
     where: /var/lib/private/vaultwarden
+    options: bind
+
+  - what: /mnt/data/ntfy
+    where: /var/lib/ntfy
     options: bind
 
 vaultwarden_domain: vault.kalnytskyi.com

--- a/roles/caddy/tasks/main.yml
+++ b/roles/caddy/tasks/main.yml
@@ -14,7 +14,6 @@
 - name: Update apt cache if needed
   ansible.builtin.apt:
     update_cache: true
-    cache_valid_time: 3600
   when: caddy_deb_repo_result.changed
   become: true
 

--- a/roles/caddy_confd/tasks/main.yml
+++ b/roles/caddy_confd/tasks/main.yml
@@ -7,3 +7,11 @@
     mode: u=rw,g=r,o=r
   notify: caddy-restart
   become: true
+
+- name: Render Ntfy configuration for Vaultwarden
+  ansible.builtin.template:
+    src: ntfy.caddy.j2
+    dest: "{{ (caddy_confd_path, 'ntfy.caddy') | path_join }}"
+    mode: u=rw,g=r,o=r
+  notify: caddy-restart
+  become: true

--- a/roles/caddy_confd/templates/ntfy.caddy.j2
+++ b/roles/caddy_confd/templates/ntfy.caddy.j2
@@ -1,0 +1,15 @@
+{{ ntfy_domain }} {
+  encode gzip zstd
+  log
+
+  header {
+    Strict-Transport-Security "max-age=31536000"
+    X-Robots-Tag "none"
+  }
+
+  reverse_proxy {{ ntfy_host }}:{{ ntfy_port }} {
+     # Passing correct remote IP address down to Ntfy so the latter can
+     # correctly ban by IP.
+     header_up X-Real-IP {remote_host}
+  }
+}

--- a/roles/kopia/tasks/main.yml
+++ b/roles/kopia/tasks/main.yml
@@ -14,7 +14,6 @@
 - name: Update apt cache if needed
   ansible.builtin.apt:
     update_cache: true
-    cache_valid_time: 3600
   when: kopia_deb_repo_result.changed
   become: true
 

--- a/roles/ntfy/defaults/main.yml
+++ b/roles/ntfy/defaults/main.yml
@@ -1,0 +1,4 @@
+---
+
+ntfy_host: 127.0.0.1
+ntfy_port: 2586

--- a/roles/ntfy/meta/main.yml
+++ b/roles/ntfy/meta/main.yml
@@ -1,0 +1,58 @@
+---
+
+argument_specs:
+  main:
+    options:
+      ntfy_domain:
+        type: str
+        required: true
+        description: |
+          The domain to serve requests from.
+      ntfy_host:
+        type: str
+        default: 127.0.0.1
+        description: |
+          The host address to bind Ntfy to.
+      ntfy_port:
+        type: int
+        default: 5000
+        description: |
+          The port to bind Ntfy to.
+      ntfy_smtp_hostname:
+        type: str
+        description: |
+          The hostname of the SMTP server used to additionally send messages as
+          email when the X-Email header is set.
+      ntfy_smtp_username:
+        type: str
+        description: |
+          The username to authenticate with the SMTP server when sending
+          messages as email.|
+      ntfy_smtp_password:
+        type: str
+        description: |
+          The password to authenticate with the SMTP server when sending
+          messages as email.
+      ntfy_smtp_from:
+        type: str
+        description: |
+          The email address to use as the sender (From) when sending messages
+          via the SMTP server.
+      ntfy_webpush_key_pub:
+        type: str
+        description: |
+          The public VAPID key used for Web Push (RFC8030) notifications.
+          Required to authenticate push messages sent from ntfy to browser push
+          services.
+      ntfy_webpush_key:
+        type: str
+        description: |
+          The private VAPID key used for Web Push (RFC8030) notifications. Must
+          be kept secret and used alongside ntfy_webpush_key_pub to sign push
+          messages.
+      ntfy_webpush_email:
+        type: str
+        description: |
+          The contact email address used in the VAPID sub (subject) field,
+          typically identifying the administrator responsible for the push
+          service.

--- a/roles/ntfy/tasks/main.yml
+++ b/roles/ntfy/tasks/main.yml
@@ -1,0 +1,48 @@
+---
+
+- name: Add ntfy deb repo
+  ansible.builtin.deb822_repository:
+    name: "{{ ntfy_deb_repo_name }}"
+    types: "{{ ntfy_deb_repo_types }}"
+    uris: "{{ ntfy_deb_repo_uris }}"
+    suites: "{{ ntfy_deb_repo_suites }}"
+    components: "{{ ntfy_deb_repo_components }}"
+    signed_by: "{{ ntfy_deb_repo_signed_by }}"
+  register: ntfy_deb_repo_result
+  become: true
+
+- name: Update apt cache if needed
+  ansible.builtin.apt:
+    update_cache: true
+  when: ntfy_deb_repo_result.changed
+  become: true
+
+- name: Install ntfy
+  ansible.builtin.apt:
+    name: ntfy
+    state: present
+  become: true
+
+- name: Remove ntfy client configuration
+  ansible.builtin.file:
+    dest: /etc/ntfy/client.yml
+    state: absent
+  become: true
+
+- name: Configure ntfy server
+  ansible.builtin.template:
+    src: server.yml.j2
+    dest: /etc/ntfy/server.yml
+    owner: ntfy
+    group: ntfy
+    mode: u=rw,g=r,o=
+  register: ntfy_server_conf_result
+  become: true
+
+- name: Start ntfy now and on every reboot
+  ansible.builtin.systemd:
+    name: ntfy.service
+    enabled: true
+    state: restarted
+    daemon_reload: true
+  become: true

--- a/roles/ntfy/templates/server.yml.j2
+++ b/roles/ntfy/templates/server.yml.j2
@@ -1,0 +1,25 @@
+attachment-cache-dir: "/var/cache/ntfy/attachments"
+attachment-total-size-limit: "1G"
+auth-default-access: "deny-all"
+auth-file: "/var/lib/ntfy/user.db"
+base-url: "https://{{ ntfy_domain }}"
+behind-proxy: true
+cache-file: "/var/cache/ntfy/cache.db"
+enable-login: true
+listen-http: "{{ ntfy_host }}:{{ ntfy_port }}"
+proxy-forwarded-header: "X-Real-IP"
+upstream-base-url: "https://ntfy.sh"
+
+{% if ntfy_smtp_hostname is defined %}
+smtp-sender-addr: "{{ ntfy_smtp_hostname }}"
+smtp-sender-user: "{{ ntfy_smtp_username }}"
+smtp-sender-pass: "{{ ntfy_smtp_password }}"
+smtp-sender-from: "{{ ntfy_smtp_from }}"
+{% endif %}
+
+{% if ntfy_webpush_key is defined %}
+web-push-public-key: "{{ ntfy_webpush_key_pub }}"
+web-push-private-key: "{{ ntfy_webpush_key }}"
+web-push-email-address: "{{ ntfy_webpush_email }}"
+web-push-file: "/var/cache/ntfy/webpush.db"
+{% endif %}

--- a/roles/ntfy/vars/main.yml
+++ b/roles/ntfy/vars/main.yml
@@ -1,0 +1,8 @@
+---
+
+ntfy_deb_repo_name: ntfy
+ntfy_deb_repo_types: deb
+ntfy_deb_repo_uris: https://archive.heckel.io/apt
+ntfy_deb_repo_suites: debian
+ntfy_deb_repo_components: main
+ntfy_deb_repo_signed_by: https://archive.heckel.io/apt/pubkey.txt

--- a/site.yml
+++ b/site.yml
@@ -9,5 +9,6 @@
     - role: jumphost
     - role: wireguard
     - role: vaultwarden
+    - role: ntfy
     - role: caddy
     - role: caddy_confd


### PR DESCRIPTION
Ntfy lets you send push notifications to your phone or desktop via scripts from any computer, using simple HTTP PUT or POST requests. This patch sets Ntfy up on the server.